### PR TITLE
사무실 출근 횟수 별로 네이버 계열사 분리

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,8 @@
 | [셀러노트](#셀러노트) | 08:00 ~ 10:00 사이 자율 출퇴근 | 필요시 재택근무 (개발팀 대부분 재택근무 중) | [홈페이지](https://www.ship-da.com/) / [채용 공고](http://wntd.co/06353222) |
 | [쿼타랩](#쿼타랩) | 완전 자율 출퇴근 | 무제한 재택근무 가능 | [홈페이지](https://www.quotabook.com/ko) / [채용 공고](https://careers.quotabook.com/) / [블로그](https://www.quotabook.com/ko/blog/home) |
 | [온다(ONDA)](#온다onda) | 8~12시 자율 출퇴근 | 필요하면 재택 | [홈페이지](https://www.onda.me/) / [채용 공고](https://together.onda.me/) / [블로그](https://www.onda.me/blog) |
-| NAVER, NAVER FINANCIAL, NAVER Cloud, WORKS MOBILE, SNOW, NAVER LABS, NAVER WEBTOON, NAVER I&S | O | 주3회출근 OR 전면재택근무 중 근무타입 선택 가능 | [채용 공고](https://recruit.navercorp.com/main.do) |
+| NAVER, NAVER FINANCIAL, NAVER Cloud, WORKS MOBILE, NAVER LABS, NAVER WEBTOON, NAVER I&S | O | 주3회출근 OR 전면재택근무 중 근무타입 선택 가능 | [채용 공고](https://recruit.navercorp.com/main.do) |
+| SNOW, NAVER Z | O | 주2회출근 OR 전면재택근무 중 근무타입 선택 가능 | [스노우 채용 공고](https://recruit.snowcorp.com) / [네이버 Z 채용 공고](https://recruit.naverz-corp.com) |
 | Presto Labs | O (완전 자율 출퇴근) | O (전세계 어디서나 완전 원격 근무) | [채용 공고 (iOS)](https://presto-career.notion.site/iOS-Software-Engineer-25011b7a929e444da9fbd6aca88dfb05) |
 | Pet Friends(펫프렌즈) | O | 격주 | [펫프렌즈 채용 페이지](https://www.wanted.co.kr/wd/79790) |
 | [모요](#모요) | 자율 출퇴근, 무제한 휴가 | 자율 재택근무 | [회사 소개](https://moyo.oopy.io/) / [채용 공고](https://www.wanted.co.kr/company/29860)


### PR DESCRIPTION
네이버의 경우 리모트 근무와 오피스 근무를 선택할 수 있는데 
오피스 선택시 사무실 출근 횟수가 주2회, 주3회 네이버 계열사 별로 달라서 정확한 정보 제공을 위해 네이버 계열사를 분리했습니다. 웹툰도 주2회로 알고 있는데 정확하지 않아서 남겨놓습니다.

새로운 회사를 추가한 것이 아니고 분리 작업이라 제일 하단이 아닌 기존 건의 바로 아래에 위치시켰습니다.